### PR TITLE
Included El Capitan check for flat distribution packages

### DIFF
--- a/createOSXinstallPkg
+++ b/createOSXinstallPkg
@@ -926,10 +926,10 @@ def main():
                 fail('%s doesn\'t look like a package!' % pkg)
             if not os.path.exists(pkg):
                 fail('Package %s not found!' % pkg)
-            if (os_version.startswith('10.10') or os_version.startswith('10.11') 
-                and not is_flat_distribution(pkg)):
+            minor_version = int(os_version.split('.')[1]
+            if (minor_version >= 10 and not is_flat_distribution(pkg)):
                 fail('%s is not a flat distribution package. '
-                     'This will cause Yosemite or El Capitan '
+                     'This will cause a 10.10+ '
                      'install to fail.' % pkg)
             print os.path.basename(pkg)
         print '----------------------------------------------------------------'

--- a/createOSXinstallPkg
+++ b/createOSXinstallPkg
@@ -926,9 +926,11 @@ def main():
                 fail('%s doesn\'t look like a package!' % pkg)
             if not os.path.exists(pkg):
                 fail('Package %s not found!' % pkg)
-            if os_version.startswith('10.10') and not is_flat_distribution(pkg):
+            if (os_version.startswith('10.10') or os_version.startswith('10.11') 
+                and not is_flat_distribution(pkg)):
                 fail('%s is not a flat distribution package. '
-                     'This will cause Yosemite install to fail.' % pkg)
+                     'This will cause Yosemite or El Capitan '
+                     'install to fail.' % pkg)
             print os.path.basename(pkg)
         print '----------------------------------------------------------------'
         total_package_size = get_size_of_all_packages(additional_packages)


### PR DESCRIPTION
Hi, I noticed that the check for flat distribution packages was not working on El Capitan COSXIP creation so have edited the script accordingly to check when 10.11