### PR TITLE
Add basic support for 10.12.4/remove ability to use custom packages

### DIFF
--- a/createOSXinstallPkg
+++ b/createOSXinstallPkg
@@ -413,8 +413,9 @@ def copy_postflight_script(output_pkg_path):
 
 
 def copy_brtool(brtool_path, output_pkg_path):
-    '''Copies brtool from the Install OS X.app into the package resources'''
-    destination = os.path.join(output_pkg_path, 'Contents/Resources/brtool')
+    '''Copies brtool from the Install OS X.app into the package resources or
+    Copies from InstallESD.dmg (10.12.4 and possibly higher.)'''
+    destination = os.path.join(output_pkg_path, 'brtool')
     try:
         shutil.copy(brtool_path, destination)
         # make sure it's executable
@@ -862,9 +863,6 @@ def main():
             source, 'Contents/SharedSupport/InstallESD.dmg')
         if not os.path.exists(installesd_dmg):
             fail('Can\'t find InstallESD.dmg at %s' % installesd_dmg)
-        brtool_path = os.path.join(source, 'Contents/Resources/brtool')
-        if not os.path.exists(brtool_path):
-            fail('Can\'t find brtool at %s' % installesd_dmg)
 
     elif source.endswith('.dmg'):
         fail('This tool no longer supports using an InstallESD.dmg as a source.'
@@ -896,6 +894,11 @@ def main():
     system_version_plist = os.path.join(
         basesystemmountpoint,
         'System/Library/CoreServices/SystemVersion.plist')
+    brtool_path = os.path.join(basesystemmountpoint, 'usr/libexec/brtool')
+    copy_brtool(brtool_path, TMPDIR)
+    brtool_path = os.path.join(TMPDIR, 'brtool')
+    if not os.path.exists(brtool_path):
+        fail('Can\'t find brtool at %s' % basesystemmountpoint)
     try:
         version_info = plistlib.readPlist(system_version_plist)
     except (ExpatError, IOError), err:

--- a/createOSXinstallPkg
+++ b/createOSXinstallPkg
@@ -413,10 +413,14 @@ def copy_postflight_script(output_pkg_path):
     fail('Could not find postflight script.')
 
 
-def copy_brtool(brtool_path, output_pkg_path):
+def copy_brtool(brtool_path, output_pkg_path, fromtemp):
     '''Copies brtool from the Install OS X.app into the package resources or
     Copies from InstallESD.dmg (10.12.4 and possibly higher.)'''
-    destination = os.path.join(output_pkg_path, 'brtool')
+    if fromtemp:
+        destination = os.path.join(output_pkg_path, 'brtool')
+    else:
+        destination = os.path.join(output_pkg_path,
+                                   'Contents/Resources/brtool')
     try:
         shutil.copy(brtool_path, destination)
         # make sure it's executable
@@ -908,7 +912,7 @@ def main():
         os_version = version_info.get('ProductUserVisibleVersion')
         if LooseVersion(os_version) >= LooseVersion('10.12.4'):
             brtool_path = os.path.join(basesystemmountpoint, 'usr/libexec/brtool')
-            copy_brtool(brtool_path, TMPDIR)
+            copy_brtool(brtool_path, TMPDIR, True)
             brtool_path = os.path.join(TMPDIR, 'brtool')
             if not os.path.exists(brtool_path):
                 fail('Can\'t find brtool at %s' % basesystemmountpoint)
@@ -1033,7 +1037,7 @@ def main():
         # clean up the broken package as well as our TMPDIR
 
         print 'Copying brtool into package resources...'
-        copy_brtool(brtool_path, output_pkg_path)
+        copy_brtool(brtool_path, output_pkg_path, False)
 
         print 'Creating MacOSXInstaller.choiceChanges...'
         makeEmptyInstallerChoiceChanges(output_pkg_path)

--- a/createOSXinstallPkg
+++ b/createOSXinstallPkg
@@ -873,6 +873,14 @@ def main():
         fail('Unknown/unsupported source: %s' % source)
 
     additional_packages = options.packages or plist_options.get('Packages', [])
+    if additional_packages:
+        app_version_plist = os.path.join(
+            source,
+            'Contents/Info.plist')
+        app_info = plistlib.readPlist(app_version_plist)
+        app_version = app_info.get('CFBundleShortVersionString')
+        if LooseVersion(app_version) >= LooseVersion('12.4.06'):
+            fail('As of 10.12.4, COSXIP cannot add custom packages.')
     if options.make_fake_app and not additional_packages:
         fail('No additional packages specified -- nothing to add to the fake '
              'install app!')

--- a/createOSXinstallPkg
+++ b/createOSXinstallPkg
@@ -35,6 +35,7 @@ import shutil
 import subprocess
 import tempfile
 
+from distutils.version import LooseVersion
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
 
@@ -894,13 +895,19 @@ def main():
     system_version_plist = os.path.join(
         basesystemmountpoint,
         'System/Library/CoreServices/SystemVersion.plist')
-    brtool_path = os.path.join(basesystemmountpoint, 'usr/libexec/brtool')
-    copy_brtool(brtool_path, TMPDIR)
-    brtool_path = os.path.join(TMPDIR, 'brtool')
-    if not os.path.exists(brtool_path):
-        fail('Can\'t find brtool at %s' % basesystemmountpoint)
     try:
         version_info = plistlib.readPlist(system_version_plist)
+        os_version = version_info.get('ProductUserVisibleVersion')
+        if LooseVersion(os_version) >= LooseVersion('10.12.4'):
+            brtool_path = os.path.join(basesystemmountpoint, 'usr/libexec/brtool')
+            copy_brtool(brtool_path, TMPDIR)
+            brtool_path = os.path.join(TMPDIR, 'brtool')
+            if not os.path.exists(brtool_path):
+                fail('Can\'t find brtool at %s' % basesystemmountpoint)
+        else:
+            brtool_path = os.path.join(source, 'Contents/Resources/brtool')
+            if not os.path.exists(brtool_path):
+                fail('Can\'t find brtool at %s' % installesd_dmg)
     except (ExpatError, IOError), err:
         unmountdmg(basesystemmountpoint)
         unmountdmg(mountpoint)
@@ -918,7 +925,6 @@ def main():
     distfile = os.path.join(expanded_osinstall_mpkg, 'Distribution')
 
     unmountdmg(mountpoint)
-    os_version = version_info.get('ProductUserVisibleVersion')
     build_number = version_info.get('ProductBuildVersion')
     if os_version is None or build_number is None:
         fail('Missing OS version or build info in %s' % system_version_plist)


### PR DESCRIPTION
This does the following:

- Add support for 10.12.4
- Keep support for prior versions
- Disable the ability to use `-p` on 10.12.4

More than likely `-p` is dead for now due to:

```
CVE-2017-6974:
Description: A validation issue existed in the handling of system installation. This issue was addressed through improved handling and validation during the installation process.
```